### PR TITLE
su: Don't start daemon for adb only mode

### DIFF
--- a/superuser.rc
+++ b/superuser.rc
@@ -9,7 +9,7 @@ on property:persist.sys.root_access=0
     stop su_daemon
 
 on property:persist.sys.root_access=2
-    start su_daemon
+    stop su_daemon
 
 on property:persist.sys.root_access=1
     start su_daemon


### PR DESCRIPTION
adb root doesn't rely on su to work, so the daemon shouldn't
be started.

Change-Id: Ice9131b7efe9344df5d77fdbc465ce0b82dbe07f